### PR TITLE
List header file as a dependent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ docs :
 graphview : $(addprefix $(OBJDIR)/,$(GRAPHVIEW_OBJS))
 	$(LD) -o $(BINDIR)/$@ $^ $(LDFLAGS) 
 
-$(OBJDIR)/%.o : $(SRCDIR)/$(notdir %.cpp)
+$(OBJDIR)/%.o : $(SRCDIR)/$(notdir %.cpp) $(SRCDIR)/$(notdir %.hpp)
 	$(CC) -c $(CFLAGS) $(CPPFLAGS) $< -o $@ 
 
 clean:


### PR DESCRIPTION
This way, when we change defined constants (i.e. DATASET_FULL in starmap.hpp), calling make will update the object files with this change.  Without this, the changes to the header file would only be included after the regular file is also updated in some way.
